### PR TITLE
Implement concatenation of generated audio

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@ python main.py config.yaml script
 python main.py config.yaml tts
 ```
 
+The TTS step produces individual MP3 files for each script entry and
+automatically concatenates them into `combined.mp3` inside the configured
+audio directory.
+
 ## Configuration
 
 `config.yaml` specifies model names, file paths and voice mapping.

--- a/tests/test_tts.py
+++ b/tests/test_tts.py
@@ -12,7 +12,11 @@ def test_script_to_audio(mock_openai):
     tmp = tempfile.TemporaryDirectory()
     script_path = Path(tmp.name) / 'script.json'
     audio_dir = Path(tmp.name) / 'audio'
-    script_path.write_text(json.dumps([{"speaker": "0", "text": "hello"}]))
+    script_data = [
+        {"speaker": "0", "text": "hello"},
+        {"speaker": "1", "text": "world"},
+    ]
+    script_path.write_text(json.dumps(script_data))
     cfg_data = {
         'models': {'summary': 'model', 'script': 'model', 'tts': 'tts'},
         'paths': {
@@ -25,9 +29,18 @@ def test_script_to_audio(mock_openai):
     }
     cfg_file = Path(tmp.name) / 'cfg.yaml'
     cfg_file.write_text(yaml.dump(cfg_data))
-    mock_openai.return_value.audio.speech.create.return_value.content = b'voice'
+    mock_client = mock_openai.return_value
+    mock_client.audio.speech.create.side_effect = [
+        type('r', (), {'content': b'voice1'}),
+        type('r', (), {'content': b'voice2'}),
+    ]
     cfg = load_config(cfg_file)
     paths = script_to_audio(cfg)
     assert Path(paths[0]).exists()
-    assert Path(paths[0]).read_bytes() == b'voice'
+    assert Path(paths[0]).read_bytes() == b'voice1'
+    assert Path(paths[1]).exists()
+    assert Path(paths[1]).read_bytes() == b'voice2'
+    # Last path is combined audio
+    assert Path(paths[-1]).exists()
+    assert Path(paths[-1]).read_bytes() == b'voice1voice2'
     tmp.cleanup()

--- a/text2cast/tts.py
+++ b/text2cast/tts.py
@@ -35,4 +35,14 @@ def script_to_audio(cfg: Config) -> list:
         with open(out_path, 'wb') as af:
             af.write(response.content)
         audio_files.append(out_path)
+
+    # Concatenate individual audio files into one
+    combined_path = os.path.join(cfg.audio_dir, 'combined.mp3')
+    logger.debug("Concatenating %d audio files into %s", len(audio_files), combined_path)
+    with open(combined_path, 'wb') as outfile:
+        for path in audio_files:
+            with open(path, 'rb') as infile:
+                outfile.write(infile.read())
+
+    audio_files.append(combined_path)
     return audio_files


### PR DESCRIPTION
## Summary
- concatenate all MP3 segments created by `script_to_audio` into a single `combined.mp3`
- document new behaviour in README
- update `test_script_to_audio` to verify merged output

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_685d499b4110832bad3bdd706d036e2c