### PR TITLE
Refactor config layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,13 +36,21 @@ tts_engine: openai
 models:
   summary: gpt-4o-mini
   script: gpt-4o-mini
-  tts: tts-1
+  tts:
+    openai: tts-1
+    volcengine: volcano_tts
+    minimax: speech-02-hd
 paths:
   input: input.txt
   brief: brief.txt
   script: script.json
   audio: audio
 speaker_voice:
-  "0": alloy
-  "1": echo
+  openai:
+    "0": alloy
+    "1": echo
+  volcengine:
+    "0": zh_male_beijingxiaoye_moon_bigtts
+  minimax:
+    "0": Chinese (Mandarin)_Warm_Bestie
 ```

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -5,26 +5,23 @@ tts_engine: volcengine
 models:
   summary: gpt-4o
   script: gpt-4o
-  # volcengine:
-  tts: volcano_tts
-  # OpenAI:
-  # tts: tts-1
-  # Minimax:
-  # tts: speech-02-hd
+  tts:
+    volcengine: volcano_tts
+    openai: tts-1
+    minimax: speech-02-hd
 paths:
   input: tmp/input.txt
   brief: tmp/brief.txt
   script: tmp/script.json
   audio: tmp/audio
 speaker_voice:
-  # volcengine
-  "1": zh_male_beijingxiaoye_moon_bigtts
-  "2": zh_female_meilinvyou_moon_bigtts
-  # ...
-
-  # OpenAI
-  # "0": alloy
-  # "1": echo
-  # ...
-  # Minimax
-  # "0": Chinese (Mandarin)_Warm_Bestie
+  volcengine:
+    "1": zh_male_beijingxiaoye_moon_bigtts
+    "2": zh_female_meilinvyou_moon_bigtts
+    # ...
+  openai:
+    "0": alloy
+    "1": echo
+    # ...
+  minimax:
+    "0": Chinese (Mandarin)_Warm_Bestie

--- a/tests/test_script_generator.py
+++ b/tests/test_script_generator.py
@@ -25,14 +25,19 @@ def test_brief_to_script(mock_openai):
     script_path = Path(tmp.name) / 'script.json'
     brief_path.write_text('brief')
     cfg_data = {
-        'models': {'summary': 'model', 'script': 'model', 'tts': 'tts'},
+        'tts_engine': 'openai',
+        'models': {
+            'summary': 'model',
+            'script': 'model',
+            'tts': {'openai': 'tts'}
+        },
         'paths': {
             'input': str(Path(tmp.name)/'input.txt'),
             'brief': str(brief_path),
             'script': str(script_path),
             'audio': str(Path(tmp.name)/'audio')
         },
-        'speaker_voice': {'0': 'a', '1': 'b'}
+        'speaker_voice': {'openai': {'0': 'a', '1': 'b'}}
     }
     cfg_file = Path(tmp.name) / 'cfg.yaml'
     cfg_file.write_text(yaml.dump(cfg_data))
@@ -52,14 +57,19 @@ def test_brief_to_script_markdown(mock_openai):
     script_path = Path(tmp.name) / 'script.json'
     brief_path.write_text('brief')
     cfg_data = {
-        'models': {'summary': 'model', 'script': 'model', 'tts': 'tts'},
+        'tts_engine': 'openai',
+        'models': {
+            'summary': 'model',
+            'script': 'model',
+            'tts': {'openai': 'tts'}
+        },
         'paths': {
             'input': str(Path(tmp.name)/'input.txt'),
             'brief': str(brief_path),
             'script': str(script_path),
             'audio': str(Path(tmp.name)/'audio')
         },
-        'speaker_voice': {'0': 'a', '1': 'b'}
+        'speaker_voice': {'openai': {'0': 'a', '1': 'b'}}
     }
     cfg_file = Path(tmp.name) / 'cfg.yaml'
     cfg_file.write_text(yaml.dump(cfg_data))
@@ -80,14 +90,19 @@ def test_brief_to_script_plain_block(mock_openai):
     script_path = Path(tmp.name) / 'script.json'
     brief_path.write_text('brief')
     cfg_data = {
-        'models': {'summary': 'model', 'script': 'model', 'tts': 'tts'},
+        'tts_engine': 'openai',
+        'models': {
+            'summary': 'model',
+            'script': 'model',
+            'tts': {'openai': 'tts'}
+        },
         'paths': {
             'input': str(Path(tmp.name)/'input.txt'),
             'brief': str(brief_path),
             'script': str(script_path),
             'audio': str(Path(tmp.name)/'audio')
         },
-        'speaker_voice': {'0': 'a', '1': 'b'}
+        'speaker_voice': {'openai': {'0': 'a', '1': 'b'}}
     }
     cfg_file = Path(tmp.name) / 'cfg.yaml'
     cfg_file.write_text(yaml.dump(cfg_data))

--- a/tests/test_summarizer.py
+++ b/tests/test_summarizer.py
@@ -23,14 +23,21 @@ def test_input_to_brief(mock_openai):
     brief_path = Path(tmp.name) / 'brief.txt'
     input_path.write_text('hello')
     cfg_data = {
-        'models': {'summary': 'model', 'script': 'model', 'tts': 'tts'},
+        'tts_engine': 'openai',
+        'models': {
+            'summary': 'model',
+            'script': 'model',
+            'tts': {'openai': 'tts'}
+        },
         'paths': {
             'input': str(input_path),
             'brief': str(brief_path),
             'script': str(Path(tmp.name) / 'script.json'),
             'audio': str(Path(tmp.name) / 'audio')
         },
-        'speaker_voice': {'0': 'a', '1': 'b'}
+        'speaker_voice': {
+            'openai': {'0': 'a', '1': 'b'}
+        }
     }
     cfg_file = Path(tmp.name) / 'cfg.yaml'
     cfg_file.write_text(yaml.dump(cfg_data))

--- a/tests/test_tts.py
+++ b/tests/test_tts.py
@@ -25,14 +25,19 @@ def test_script_to_audio(mock_openai):
     ]
     script_path.write_text(json.dumps(script_data))
     cfg_data = {
-        'models': {'summary': 'model', 'script': 'model', 'tts': 'tts'},
+        'tts_engine': 'openai',
+        'models': {
+            'summary': 'model',
+            'script': 'model',
+            'tts': {'openai': 'tts'}
+        },
         'paths': {
             'input': str(Path(tmp.name)/'input.txt'),
             'brief': str(Path(tmp.name)/'brief.txt'),
             'script': str(script_path),
             'audio': str(audio_dir)
         },
-        'speaker_voice': {'0': 'a', '1': 'b'}
+        'speaker_voice': {'openai': {'0': 'a', '1': 'b'}}
     }
     cfg_file = Path(tmp.name) / 'cfg.yaml'
     cfg_file.write_text(yaml.dump(cfg_data))
@@ -65,14 +70,20 @@ def test_script_to_audio_volc(mock_post):
     script_path.write_text(json.dumps(script_data))
     cfg_data = {
         'tts_engine': 'volcengine',
-        'models': {'summary': 'model', 'script': 'model', 'tts': 'cn_zhiyan_emo'},
+        'models': {
+            'summary': 'model',
+            'script': 'model',
+            'tts': {'volcengine': 'cn_zhiyan_emo'}
+        },
         'paths': {
             'input': str(Path(tmp.name)/'input.txt'),
             'brief': str(Path(tmp.name)/'brief.txt'),
             'script': str(script_path),
             'audio': str(audio_dir)
         },
-        'speaker_voice': {'0': 'a', '1': 'b'}
+        'speaker_voice': {
+            'volcengine': {'0': 'a', '1': 'b'}
+        }
     }
     cfg_file = Path(tmp.name) / 'cfg.yaml'
     cfg_file.write_text(yaml.dump(cfg_data))
@@ -114,14 +125,20 @@ def test_script_to_audio_minimax(mock_post):
     script_path.write_text(json.dumps(script_data))
     cfg_data = {
         'tts_engine': 'minimax',
-        'models': {'summary': 'm', 'script': 'm', 'tts': 'speech-02-hd'},
+        'models': {
+            'summary': 'm',
+            'script': 'm',
+            'tts': {'minimax': 'speech-02-hd'}
+        },
         'paths': {
             'input': str(Path(tmp.name)/'input.txt'),
             'brief': str(Path(tmp.name)/'brief.txt'),
             'script': str(script_path),
             'audio': str(audio_dir)
         },
-        'speaker_voice': {'0': 'a', '1': 'b'}
+        'speaker_voice': {
+            'minimax': {'0': 'a', '1': 'b'}
+        }
     }
     cfg_file = Path(tmp.name) / 'cfg.yaml'
     cfg_file.write_text(yaml.dump(cfg_data))

--- a/text2cast/config.py
+++ b/text2cast/config.py
@@ -31,16 +31,30 @@ def load_config(path: str) -> Config:
     with open(path, 'r', encoding='utf-8') as f:
         data = yaml.safe_load(f)
     load_env_vars()
+    tts_engine = data.get('tts_engine', 'openai')
+    logger.debug("Selected tts_engine: %s", tts_engine)
+
+    tts_model = None
+    if isinstance(data.get('models', {}).get('tts'), dict):
+        tts_model = data['models']['tts'].get(tts_engine)
+    else:
+        tts_model = data['models'].get('tts')
+    logger.debug("tts_model resolved to: %s", tts_model)
+
+    speaker_voice = data.get('speaker_voice', {})
+    if isinstance(speaker_voice, dict) and tts_engine in speaker_voice:
+        speaker_voice = speaker_voice[tts_engine]
+
     return Config(
         model_summary=data['models']['summary'],
         model_script=data['models']['script'],
-        tts_model=data['models']['tts'],
+        tts_model=tts_model,
         input_path=data['paths']['input'],
         brief_path=data['paths']['brief'],
         script_path=data['paths']['script'],
         audio_dir=data['paths']['audio'],
-        speaker_voice=data['speaker_voice'],
-        tts_engine=data.get('tts_engine', 'openai'),
+        speaker_voice=speaker_voice,
+        tts_engine=tts_engine,
     )
 
 def load_env_vars() -> None:


### PR DESCRIPTION
## Summary
- change YAML format to nest voices and tts models per engine
- adjust config loader for new structure
- update example config and README
- update tests for new yaml schema

## Testing
- `pip install -q -r requirements.txt` *(fails: Tunnel connection failed: 403 Forbidden)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_685e4aade074832b96c0a7d6b1f94550