### PR TITLE
Add packaging support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,25 +2,28 @@
 
 A pipeline that converts long text into a podcast script and audio.
 
+Install the package with `pip` and run the command line interface `text2cast`.
+
 ## Usage
 
 1. Copy `config.yaml.example` to `config.yaml` and edit paths and voices.
 2. Copy `.env.example` to `.env` and fill in `OPENAI_API_KEY` or `DEEPSEEK_API_KEY`,
    `VOLCENGINE_TOKEN`/`VOLCENGINE_APP_ID`, or `MINIMAX_API_KEY`/`MINIMAX_GROUP_ID`
    depending on the TTS engine.
-3. Place your input text at the configured input path.
-4. Run the full pipeline:
+3. Install the package (for local development use `pip install -e .`).
+4. Place your input text at the configured input path.
+5. Run the full pipeline:
 
 ```bash
-python main.py config.yaml all
+text2cast config.yaml all
 ```
 
 Or run individual steps:
 
 ```bash
-python main.py config.yaml summary
-python main.py config.yaml script
-python main.py config.yaml tts
+text2cast config.yaml summary
+text2cast config.yaml script
+text2cast config.yaml tts
 ```
 
 The TTS step produces individual MP3 files for each script entry and

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,22 @@
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "text2cast"
+version = "0.1.0"
+description = "Pipeline that converts long text into a podcast script and audio."
+readme = "README.md"
+requires-python = ">=3.8"
+dependencies = [
+    "openai",
+    "pyyaml",
+    "python-dotenv",
+    "requests",
+]
+
+[project.optional-dependencies]
+test = ["pytest"]
+
+[project.scripts]
+text2cast = "text2cast.cli:main"

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,3 @@ pyyaml
 python-dotenv
 pytest
 requests
-PyYAML

--- a/text2cast/__init__.py
+++ b/text2cast/__init__.py
@@ -1,8 +1,12 @@
+"""Public API for the Text2Cast package."""
+
 from .config import load_config, Config
 from .summarizer import input_to_brief
 from .script_generator import brief_to_script
 from .utils import wash_json
 from .tts import script_to_audio
+
+__version__ = "0.1.0"
 
 __all__ = [
     'load_config',
@@ -11,4 +15,5 @@ __all__ = [
     'brief_to_script',
     'script_to_audio',
     'wash_json',
+    '__version__',
 ]

--- a/text2cast/__main__.py
+++ b/text2cast/__main__.py
@@ -1,4 +1,4 @@
-from text2cast.cli import main
+from .cli import main
 
 if __name__ == "__main__":
     main()

--- a/text2cast/cli.py
+++ b/text2cast/cli.py
@@ -1,0 +1,47 @@
+import argparse
+import logging
+
+from .config import load_config
+from .summarizer import input_to_brief
+from .script_generator import brief_to_script
+from .tts import script_to_audio
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+
+def run_all(cfg_path: str) -> None:
+    """Run the full text-to-podcast pipeline."""
+    logger.info("Running full pipeline with config %s", cfg_path)
+    cfg = load_config(cfg_path)
+    input_to_brief(cfg)
+    brief_to_script(cfg)
+    script_to_audio(cfg)
+
+
+def main() -> None:
+    """CLI entry point."""
+    parser = argparse.ArgumentParser(description="Text2Cast pipeline")
+    parser.add_argument("config", help="Path to config.yaml")
+    sub = parser.add_subparsers(dest="command")
+    sub.add_parser("summary")
+    sub.add_parser("script")
+    sub.add_parser("tts")
+    sub.add_parser("all")
+    args = parser.parse_args()
+    cfg = load_config(args.config)
+    if args.command == "summary":
+        logger.info("Running summarization step")
+        input_to_brief(cfg)
+    elif args.command == "script":
+        logger.info("Running script generation step")
+        brief_to_script(cfg)
+    elif args.command == "tts":
+        logger.info("Running TTS step")
+        script_to_audio(cfg)
+    else:
+        run_all(args.config)
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution
+    main()


### PR DESCRIPTION
## Summary
- create a `pyproject.toml` defining the `text2cast` package
- provide a CLI entry point in `text2cast.cli`
- expose version in the package API
- adjust README for installation and CLI usage
- clean up `requirements.txt`
- keep backward compatible `main.py`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_685eb23b9620832b84e44c7916ab18f5