### PR TITLE
Add CLI overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,12 @@ text2cast config.yaml script
 text2cast config.yaml tts
 ```
 
+You can override configuration values on the command line, for example
+
+```bash
+text2cast config.yaml all --tts_engine openai --speaker_voice 0=alloy,1=echo
+```
+
 The TTS step produces individual MP3 files for each script entry and
 automatically concatenates them into `combined.mp3` inside the configured
 audio directory.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,45 @@
+import sys
+from pathlib import Path
+import yaml
+import tempfile
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from text2cast.cli import main
+
+
+def test_cli_overrides(monkeypatch):
+    tmp = tempfile.TemporaryDirectory()
+    cfg_data = {
+        'tts_engine': 'openai',
+        'chat_engine': 'openai',
+        'models': {
+            'summary': {'openai': 'model'},
+            'script': {'openai': 'model'},
+            'tts': {'openai': 'tts'}
+        },
+        'paths': {
+            'input': str(Path(tmp.name)/'input.txt'),
+            'brief': str(Path(tmp.name)/'brief.txt'),
+            'script': str(Path(tmp.name)/'script.json'),
+            'audio': str(Path(tmp.name)/'audio')
+        },
+        'speaker_voice': {'openai': {'0': 'a'}}
+    }
+    cfg_file = Path(tmp.name) / 'cfg.yaml'
+    cfg_file.write_text(yaml.dump(cfg_data))
+
+    called = {}
+    def fake_summary(cfg):
+        called['voice'] = cfg.speaker_voice['0']
+    monkeypatch.setattr('text2cast.cli.input_to_brief', fake_summary)
+    monkeypatch.setattr('text2cast.cli.brief_to_script', lambda cfg: None)
+    monkeypatch.setattr('text2cast.cli.script_to_audio', lambda cfg: None)
+
+    monkeypatch.setattr(sys, 'argv', [
+        'text2cast', str(cfg_file), 'summary', '--speaker_voice', '0=voice'
+    ])
+
+    main()
+    assert called['voice'] == 'voice'
+    tmp.cleanup()

--- a/text2cast/cli.py
+++ b/text2cast/cli.py
@@ -1,7 +1,7 @@
 import argparse
 import logging
 
-from .config import load_config
+from .config import load_config, Config
 from .summarizer import input_to_brief
 from .script_generator import brief_to_script
 from .tts import script_to_audio
@@ -10,10 +10,43 @@ logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 
-def run_all(cfg_path: str) -> None:
+def apply_overrides(cfg: Config, args: argparse.Namespace) -> Config:
+    """Apply command line overrides to the config object."""
+    if args.tts_engine:
+        cfg.tts_engine = args.tts_engine
+    if args.chat_engine:
+        cfg.chat_engine = args.chat_engine
+    if args.tts_model:
+        cfg.tts_model = args.tts_model
+    if args.model_summary:
+        cfg.model_summary = args.model_summary
+    if args.model_script:
+        cfg.model_script = args.model_script
+    if args.input_path:
+        cfg.input_path = args.input_path
+    if args.brief_path:
+        cfg.brief_path = args.brief_path
+    if args.script_path:
+        cfg.script_path = args.script_path
+    if args.audio_dir:
+        cfg.audio_dir = args.audio_dir
+
+    if args.speaker_voice:
+        for item in args.speaker_voice:
+            for pair in item.split(','):
+                if '=' not in pair:
+                    raise ValueError(
+                        "speaker_voice must be of the form speaker=voice"
+                    )
+                k, v = pair.split('=', 1)
+                cfg.speaker_voice[k] = v
+
+    return cfg
+
+
+def run_all(cfg: Config) -> None:
     """Run the full text-to-podcast pipeline."""
-    logger.info("Running full pipeline with config %s", cfg_path)
-    cfg = load_config(cfg_path)
+    logger.info("Running full pipeline")
     input_to_brief(cfg)
     brief_to_script(cfg)
     script_to_audio(cfg)
@@ -23,6 +56,23 @@ def main() -> None:
     """CLI entry point."""
     parser = argparse.ArgumentParser(description="Text2Cast pipeline")
     parser.add_argument("config", help="Path to config.yaml")
+    parser.add_argument("--tts_engine")
+    parser.add_argument("--chat_engine")
+    parser.add_argument("--tts_model")
+    parser.add_argument("--model_summary")
+    parser.add_argument("--model_script")
+    parser.add_argument("--input_path")
+    parser.add_argument("--brief_path")
+    parser.add_argument("--script_path")
+    parser.add_argument("--audio_dir")
+    parser.add_argument(
+        "--speaker_voice",
+        action="append",
+        help=(
+            "Override speaker to voice mapping, format: speaker=voice. "
+            "Can be used multiple times or with comma separated pairs."
+        ),
+    )
     sub = parser.add_subparsers(dest="command")
     sub.add_parser("summary")
     sub.add_parser("script")
@@ -30,6 +80,7 @@ def main() -> None:
     sub.add_parser("all")
     args = parser.parse_args()
     cfg = load_config(args.config)
+    cfg = apply_overrides(cfg, args)
     if args.command == "summary":
         logger.info("Running summarization step")
         input_to_brief(cfg)
@@ -40,7 +91,7 @@ def main() -> None:
         logger.info("Running TTS step")
         script_to_audio(cfg)
     else:
-        run_all(args.config)
+        run_all(cfg)
 
 
 if __name__ == "__main__":  # pragma: no cover - manual execution


### PR DESCRIPTION
## Summary
- allow overriding configuration via command line options
- document CLI overrides in README
- test CLI override functionality

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `pip install pyyaml` *(fails due to network restriction)*

------
https://chatgpt.com/codex/tasks/task_e_685eb436ff14832b8097398f7da993d6