### PR TITLE
Enable voice cloning via CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,14 @@ voice_id = clone_voice([
 print("New voice id:", voice_id)
 ```
 
+Alternatively the CLI provides a `clone` command:
+
+```bash
+text2cast config.yaml clone --clone_sample sample1.wav --clone_sample sample2.wav --clone_name my_voice
+```
+
+These parameters can also be set in `config.yaml` under `voice_clone`.
+
 The resulting `voice_id` can be configured in `speaker_voice` for later
 synthesis.
 
@@ -85,4 +93,9 @@ speaker_voice:
     "0": zh_male_beijingxiaoye_moon_bigtts
   minimax:
     "0": Chinese (Mandarin)_Warm_Bestie
+voice_clone:
+  name: my_voice
+  samples:
+    - sample1.wav
+    - sample2.wav
 ```

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -30,3 +30,8 @@ speaker_voice:
     # ...
   minimax:
     "0": Chinese (Mandarin)_Warm_Bestie
+voice_clone:
+  name: my_voice
+  samples:
+    - sample1.wav
+    - sample2.wav

--- a/text2cast/config.py
+++ b/text2cast/config.py
@@ -1,6 +1,6 @@
 import os
-from dataclasses import dataclass
-from typing import Dict
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional
 try:
     from dotenv import load_dotenv
 except Exception:  # pragma: no cover - fallback when dotenv is missing
@@ -23,6 +23,8 @@ class Config:
     script_path: str
     audio_dir: str
     speaker_voice: Dict[str, str]
+    voice_clone_samples: List[str] = field(default_factory=list)
+    voice_clone_name: Optional[str] = None
     tts_engine: str = "openai"
     chat_engine: str = "openai"
 
@@ -56,6 +58,10 @@ def load_config(path: str) -> Config:
     if isinstance(model_script, dict):
         model_script = model_script.get(chat_engine)
 
+    vc = data.get('voice_clone', {})
+    voice_clone_name = vc.get('name')
+    voice_clone_samples = vc.get('samples', []) if isinstance(vc, dict) else []
+
     return Config(
         model_summary=model_summary,
         model_script=model_script,
@@ -65,6 +71,8 @@ def load_config(path: str) -> Config:
         script_path=data['paths']['script'],
         audio_dir=data['paths']['audio'],
         speaker_voice=speaker_voice,
+        voice_clone_samples=voice_clone_samples,
+        voice_clone_name=voice_clone_name,
         tts_engine=tts_engine,
         chat_engine=chat_engine,
     )


### PR DESCRIPTION
## Summary
- add `voice_clone` options in config loading
- add CLI command `clone` with `--clone_sample` and `--clone_name` arguments
- document cloning command and config section in README
- update example config file

## Testing
- `python -m py_compile text2cast/cli.py text2cast/config.py`
- `pytest -q` *(no tests found)*
- `pip install pyyaml` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6863ae71b894832bb97330299c883401