### PR TITLE
Add script_v2 using Firecrawl

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
     "pyyaml",
     "python-dotenv",
     "requests",
+    "firecrawl",
 ]
 
 [project.optional-dependencies]

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ pyyaml
 python-dotenv
 pytest
 requests
+firecrawl

--- a/text2cast/cli.py
+++ b/text2cast/cli.py
@@ -4,6 +4,7 @@ import logging
 from .config import load_config, Config
 from .summarizer import input_to_brief
 from .script_generator import brief_to_script
+from .script_v2 import urls_to_script
 from .tts import script_to_audio
 from .voice_clone import clone_voice
 
@@ -97,6 +98,7 @@ def main() -> None:
     sub = parser.add_subparsers(dest="command")
     sub.add_parser("summary")
     sub.add_parser("script")
+    sub.add_parser("script_v2")
     sub.add_parser("tts")
     sub.add_parser("all")
     sub.add_parser("clone")
@@ -111,6 +113,9 @@ def main() -> None:
     elif args.command == "script":
         logger.info("Running script generation step")
         brief_to_script(cfg)
+    elif args.command == "script_v2":
+        logger.info("Running script_v2 generation step")
+        urls_to_script(cfg)
     elif args.command == "tts":
         logger.info("Running TTS step")
         script_to_audio(cfg)

--- a/text2cast/script_v2.py
+++ b/text2cast/script_v2.py
@@ -1,0 +1,73 @@
+import json
+import logging
+from typing import List, Dict
+
+import openai
+from firecrawl import FirecrawlApp
+
+from .config import Config, OPENAI_API_KEY, DEEPSEEK_API_KEY
+
+logger = logging.getLogger(__name__)
+
+
+def urls_to_script(cfg: Config) -> List[Dict[str, str]]:
+    """Generate script entries from article URLs.
+
+    The input file specified by ``cfg.input_path`` must be a JSON file with
+    ``global`` and ``local`` lists, each containing objects with ``title`` and
+    ``url`` fields.
+    """
+    logger.debug("Reading articles from %s", cfg.input_path)
+    with open(cfg.input_path, "r", encoding="utf-8") as f:
+        data = json.load(f)
+
+    articles = data.get("global", []) + data.get("local", [])
+
+    if not articles:
+        raise ValueError("No articles found in input file")
+
+    logger.debug("Creating Firecrawl client")
+    fc = FirecrawlApp()
+
+    logger.debug("Creating OpenAI client for summarization")
+    if cfg.chat_engine == "deepseek":
+        client = openai.OpenAI(api_key=DEEPSEEK_API_KEY, base_url="https://api.deepseek.com")
+    else:
+        client = openai.OpenAI(api_key=OPENAI_API_KEY)
+
+    script: List[Dict[str, str]] = []
+    speaker = 1
+
+    for article in articles:
+        title = article.get("title", "")
+        url = article.get("url")
+        logger.info("Processing %s", url)
+
+        content = ""
+        try:
+            result = fc.scrape_url(url, formats=["markdown"])
+            content = result.markdown or ""
+        except Exception as e:
+            logger.warning("Failed to scrape %s: %s", url, e)
+
+        summary = ""
+        if content:
+            try:
+                prompt = f"请用中文用1-2句话总结这篇文章的主要内容：{content}"
+                resp = client.chat.completions.create(
+                    model=cfg.model_script,
+                    messages=[{"role": "user", "content": prompt}],
+                )
+                summary = resp.choices[0].message.content.strip()
+            except Exception as e:
+                logger.warning("Failed to summarize %s: %s", url, e)
+
+        text = f"{title} {summary}".strip()
+        script.append({"speaker": str(speaker), "text": text})
+        speaker = 1 if speaker == 2 else 2
+
+    logger.debug("Writing script to %s", cfg.script_path)
+    with open(cfg.script_path, "w", encoding="utf-8") as f:
+        json.dump(script, f, ensure_ascii=False, indent=2)
+
+    return script


### PR DESCRIPTION
## Summary
- add Firecrawl dependency
- add `urls_to_script` to generate podcast script directly from article URLs
- wire new command `script_v2` into CLI

## Testing
- `python -m py_compile text2cast/*.py`
- `pip install -e .`

------
https://chatgpt.com/codex/tasks/task_e_6876004fb56883279b14e75d5fc29b89