### PR TITLE
Add configurable sound effect paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,9 @@ audio directory.
 
 Each script entry has a `type` field. Entries with `type: tts` contain
 spoken text along with a `speaker` ID, while `type: sound_effect` provides
-the path to an audio clip to insert in the final mix.
+the path to an audio clip to insert in the final mix. Sound effect paths
+used by `script_v2` are configured in the `sound_effects` section of
+`config.yaml`.
 
 ## Voice cloning with Volcengine
 
@@ -89,6 +91,11 @@ paths:
   brief: brief.txt
   script: script.json
   audio: audio
+sound_effects:
+  intro: intro.mp3
+  article_end: article_end.mp3
+  transition: transition.mp3
+  outro: outro.mp3
 speaker_voice:
   openai:
     "0": alloy

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -19,6 +19,11 @@ paths:
   brief: tmp/brief.txt
   script: tmp/script.json
   audio: tmp/audio
+sound_effects:
+  intro: intro.mp3
+  article_end: article_end.mp3
+  transition: transition.mp3
+  outro: outro.mp3
 speaker_voice:
   volcengine:
     # "1": zh_female_linjianvhai_moon_bigtts

--- a/text2cast/config.py
+++ b/text2cast/config.py
@@ -23,6 +23,7 @@ class Config:
     script_path: str
     audio_dir: str
     speaker_voice: Dict[str, str]
+    sound_effects: Dict[str, str] = field(default_factory=dict)
     voice_clone_samples: List[str] = field(default_factory=list)
     voice_clone_name: Optional[str] = None
     tts_engine: str = "openai"
@@ -62,6 +63,8 @@ def load_config(path: str) -> Config:
     voice_clone_name = vc.get('name')
     voice_clone_samples = vc.get('samples', []) if isinstance(vc, dict) else []
 
+    sound_effects = data.get('sound_effects', {})
+
     return Config(
         model_summary=model_summary,
         model_script=model_script,
@@ -71,6 +74,7 @@ def load_config(path: str) -> Config:
         script_path=data['paths']['script'],
         audio_dir=data['paths']['audio'],
         speaker_voice=speaker_voice,
+        sound_effects=sound_effects,
         voice_clone_samples=voice_clone_samples,
         voice_clone_name=voice_clone_name,
         tts_engine=tts_engine,

--- a/text2cast/script_v2.py
+++ b/text2cast/script_v2.py
@@ -56,7 +56,8 @@ def urls_to_script(cfg: Config) -> List[Dict[str, str]]:
             "type": "tts",
         }
     )
-    script.append({"type": "sound_effect", "path": "intro.mp3"})
+    intro_path = cfg.sound_effects.get("intro", "intro.mp3")
+    script.append({"type": "sound_effect", "path": intro_path})
 
     speaker = 1
 
@@ -102,11 +103,13 @@ def urls_to_script(cfg: Config) -> List[Dict[str, str]]:
 
         text = f"{title} {summary}".strip()
         script.append({"speaker": str(speaker), "text": text, "type": "tts"})
-        script.append({"type": "sound_effect", "path": "article_end.mp3"})
+        article_end = cfg.sound_effects.get("article_end", "article_end.mp3")
+        script.append({"type": "sound_effect", "path": article_end})
         speaker = 1 if speaker == 2 else 2
 
     if local_articles:
-        script.append({"type": "sound_effect", "path": "transition.mp3"})
+        transition = cfg.sound_effects.get("transition", "transition.mp3")
+        script.append({"type": "sound_effect", "path": transition})
 
     for article in local_articles:
         title = article.get("title", "")
@@ -134,7 +137,8 @@ def urls_to_script(cfg: Config) -> List[Dict[str, str]]:
 
         text = f"{title} {summary}".strip()
         script.append({"speaker": str(speaker), "text": text, "type": "tts"})
-        script.append({"type": "sound_effect", "path": "article_end.mp3"})
+        article_end = cfg.sound_effects.get("article_end", "article_end.mp3")
+        script.append({"type": "sound_effect", "path": article_end})
         speaker = 1 if speaker == 2 else 2
 
     script.append(
@@ -152,7 +156,8 @@ def urls_to_script(cfg: Config) -> List[Dict[str, str]]:
             "type": "tts",
         }
     )
-    script.append({"type": "sound_effect", "path": "outro.mp3"})
+    outro_path = cfg.sound_effects.get("outro", "outro.mp3")
+    script.append({"type": "sound_effect", "path": outro_path})
 
     logger.debug("Writing script to %s", cfg.script_path)
     with open(cfg.script_path, "w", encoding="utf-8") as f:

--- a/text2cast/tts.py
+++ b/text2cast/tts.py
@@ -43,7 +43,12 @@ def script_to_audio(cfg: Config) -> list:
 
     for idx, item in enumerate(script):
         if item.get("type") == "sound_effect":
-            audio_files.append(item.get("path"))
+            se_path = item.get("path")
+            if not os.path.isabs(se_path):
+                se_path = os.path.join(cfg.audio_dir, se_path)
+            if not os.path.exists(se_path):
+                logger.warning("Sound effect %s does not exist", se_path)
+            audio_files.append(se_path)
             continue
 
         speaker = item.get("speaker", "0")


### PR DESCRIPTION
## Summary
- allow setting sound effect paths in `config.yaml`
- reference configured paths in `script_v2`
- treat sound effect paths as relative to the audio directory when combining audio
- document new configuration field in README

## Testing
- `python -m pip install -e .`
- `pytest -q`
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_687641557c188327a7ce4a0c3599699a